### PR TITLE
automate bbc partition assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This workflow runs STARsolo with the appropriate parameters for the particular s
 
    **For variant calling**, set 'call_variants' to True. **To variant call only a subset of the cell barcodes**, specify only those barcodes in the 'sample_decoder' file. See config file for more info.
 
-5. Run `qsub -q bbc bin/run_snakemake.sh`.
+5. Run `sbatch bin/run_snakemake.sh`.
 
 # Helpful commands
 `snakemake -l`: Print all the rules and a description of what it does.

--- a/bin/run_snakemake.sh
+++ b/bin/run_snakemake.sh
@@ -10,6 +10,12 @@
 
 set -euo pipefail
 
+# If you're in the BBC, this script will use the bbc partition by default.
+# If BBC members want to override this and use a different partition,
+# specify your desired partition in the header above, 
+# and set the "bbc_use_specified_sbatch_partition" variable to true.
+bbc_use_specified_sbatch_partition=false
+
 cd "$SLURM_SUBMIT_DIR"
 
 snakemake_module="bbc2/snakemake/snakemake-7.25.0"
@@ -22,12 +28,20 @@ logs_dir="logs/"
 
 
 echo "Start snakemake workflow." >&1                   
-echo "Start snakemake workflow." >&2     
+echo "Start snakemake workflow." >&2    
+
+# if user belongs to a group with "bbc" in the name, then set slurm partition to "bbc"
+# if the bbc_use_specified_sbatch_partition variable is set to true, then use the SLURM_JOB_PARTITION variable.
+if [[ $(groups) =~ bbc ]]; then
+    if [[ $bbc_use_specified_sbatch_partition == false ]]; then
+        SLURM_JOB_PARTITION="bbc"
+    fi
+fi
 
 snakemake \
 -p \
 --latency-wait 20 \
---snakefile 'Snakefile' \
+--snakefile 'Snakefile2' \
 --use-envmodules \
 --jobs 100 \
 --cluster "mkdir -p logs/{rule}; sbatch \

--- a/bin/run_snakemake.sh
+++ b/bin/run_snakemake.sh
@@ -41,7 +41,7 @@ fi
 snakemake \
 -p \
 --latency-wait 20 \
---snakefile 'Snakefile2' \
+--snakefile 'Snakefile' \
 --use-envmodules \
 --jobs 100 \
 --cluster "mkdir -p logs/{rule}; sbatch \

--- a/bin/run_snakemake.sh
+++ b/bin/run_snakemake.sh
@@ -36,6 +36,12 @@ if [[ $(groups) =~ bbc ]]; then
     if [[ $bbc_use_specified_sbatch_partition == false ]]; then
         SLURM_JOB_PARTITION="bbc"
     fi
+else
+    # if SLURM_JOB_PARTITION is bbc but user isn't in the BBC, error with message.
+    if [[ $SLURM_JOB_PARTITION == "bbc" ]]; then
+        echo "You are not a member of the BBC, so you cannot use the bbc partition. Please specify a different partition." >&2
+        exit 1
+    fi
 fi
 
 snakemake \


### PR DESCRIPTION
Default BBC members to run child jobs on bbc partition, while preventing other users from doing so. BBC members can override default bbc partition assignment by setting override variable to `true`.

What do we think? Did I overcomplicate this? Fellow BBC members, let me know your thoughts/feedback, and I can try to implement a easier & more user-friendly option instead.